### PR TITLE
impr: add cli --version option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,12 @@ GORUN=$(GOCMD) run
 BINARY_NAME=depbot
 BINARY_UNIX=$(BINARY_NAME)_unix
 
+LAUNCH=$(GORUN) $$(ls -1 cmd/depbot/*.go | grep -v _test.go)
+
 run:
-	$(GORUN) $$(ls -1 cmd/depbot/*.go | grep -v _test.go)
+	$(LAUNCH)
+version:
+	$(LAUNCH) --version
 build: 
 	$(GOBUILD) -o $(BINARY_NAME) $$(ls -1 cmd/depbot/*.go | grep -v _test.go)
 test: 

--- a/cmd/depbot/main.go
+++ b/cmd/depbot/main.go
@@ -1,6 +1,19 @@
 package main
 
-func main() {
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+const version = "0.2.3"
+
+func displayAppVersion() {
+	fmt.Printf("Depbot %s\n", version)
+	os.Exit(0)
+}
+
+func launchApplicaton() {
 	// display introduction text
 	printIntroductoryText()
 
@@ -37,4 +50,15 @@ func main() {
 	// write configration data to yaml file
 	yamlData := config.ConvertToYaml()
 	createDependabotYamlFile(yamlData)
+	os.Exit(0)
+}
+
+func main() {
+	showVersion := flag.Bool("version", false, "Display app version")
+	flag.Parse()
+	if *showVersion {
+		displayAppVersion()
+	} else {
+		launchApplicaton()
+	}
 }


### PR DESCRIPTION
Displays app version when the `depbot --version` is run

fixes #16 