### PR TITLE
feat: add help command flag to cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ LAUNCH=$(GORUN) $$(ls -1 cmd/depbot/*.go | grep -v _test.go)
 
 run:
 	$(LAUNCH)
+help:
+	$(LAUNCH) --help
 version:
 	$(LAUNCH) --version
 web:

--- a/cmd/depbot/main.go
+++ b/cmd/depbot/main.go
@@ -13,6 +13,12 @@ func displayAppVersion() {
 	os.Exit(0)
 }
 
+func displayHelpText() {
+	text := getCliHelpText()
+	fmt.Printf("%s", text)
+	os.Exit(0)
+}
+
 func handlePromptError(err error) {
 	if err != nil {
 		os.Exit(0)
@@ -93,12 +99,15 @@ func launchApplicaton() {
 func main() {
 	showVersion := flag.Bool("version", false, "Display app version")
 	startWebApp := flag.Bool("web", false, "Start web application")
+	displayHelp := flag.Bool("help", false, "Display help text")
 
 	flag.Parse()
 	if *showVersion {
 		displayAppVersion()
 	} else if *startWebApp {
 		startWebApplication()
+	} else if *displayHelp {
+		displayHelpText()
 	} else {
 		launchApplicaton()
 	}

--- a/cmd/depbot/utils.go
+++ b/cmd/depbot/utils.go
@@ -11,7 +11,20 @@ const (
 	dependabotFileName = "dependabot.yml"
 	githubDirectory    = ".github"
 	pathSeperator      = "/"
+	cliHelpText        = `Depbot - A CLI tool to help you configure dependabot in your project
+  Usage:
+  depbot [flags]
+
+  Flags:
+  --help     -h  Show help
+  --version  -v Display app version
+  --web      -w    Start web application
+`
 )
+
+func getCliHelpText() string {
+	return cliHelpText
+}
 
 func printIntroductoryText() {
 	green := "\033[32m"
@@ -47,7 +60,6 @@ func fileExists(filename string) bool {
 func createDirectoryIfItDoesNotExist(dir string) (hasCreatedNewDir bool, err error) {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		err := os.Mkdir(dir, 0755)
-
 		if err != nil {
 			log.Fatalf("Error creating directory %s: %v", dir, err)
 			return false, err

--- a/cmd/depbot/utils_test.go
+++ b/cmd/depbot/utils_test.go
@@ -77,3 +77,9 @@ func TestFileExistsWhenFileAlrieadyExists(t *testing.T) {
 
 	assert.Equal(t, hasFile, true)
 }
+
+func TestGetCliHelpText(t *testing.T) {
+	text := getCliHelpText()
+
+	assert.Equal(t, text, cliHelpText)
+}


### PR DESCRIPTION
fixes #28
This allows you to run `depbot --help` on your terminal to get the help notes